### PR TITLE
Modify adding appointments to allow users specify only start date instead of specific date

### DIFF
--- a/WebClinicAPI/Controllers/AppointmentsController.cs
+++ b/WebClinicAPI/Controllers/AppointmentsController.cs
@@ -63,8 +63,27 @@ namespace WebClinicAPI.Controllers
                 {
                     while (currentDayTime < endDayTime)
                     {
-                        var closestAppointmentTime = appointments.ElementAt(0).Time;
-                        if (closestAppointmentTime - currentDayTime >= defaultAppointmentTimeSpan)
+                        if (appointments.Count > 0)
+                        {
+                            var closestAppointmentTime = appointments.ElementAt(0).Time;
+                            if (closestAppointmentTime - currentDayTime >= defaultAppointmentTimeSpan)
+                            {
+                                freeAppointments.Add(new Appointment
+                                {
+                                    Physician = physician,
+                                    PhysicianId = physician.Id,
+                                    Time = currentDayTime,
+                                    Type = type
+                                });
+                                currentDayTime = currentDayTime.Add(defaultAppointmentTimeSpan);
+                            }
+                            else
+                            {
+                                currentDayTime = closestAppointmentTime.Add(defaultAppointmentTimeSpan);
+                                appointments.RemoveAt(0);
+                            }
+                        }
+                        else
                         {
                             freeAppointments.Add(new Appointment
                             {
@@ -74,11 +93,6 @@ namespace WebClinicAPI.Controllers
                                 Type = type
                             });
                             currentDayTime = currentDayTime.Add(defaultAppointmentTimeSpan);
-                        }
-                        else
-                        {
-                            currentDayTime = closestAppointmentTime + defaultAppointmentTimeSpan;
-                            appointments.RemoveAt(0);
                         }
                     }
                     // Go to next day

--- a/WebClinicAPI/Data/ApplicationDbContext.cs
+++ b/WebClinicAPI/Data/ApplicationDbContext.cs
@@ -114,7 +114,7 @@ namespace WebClinicAPI.Data
                     Id = 2,
                     PatientId = 6,
                     PhysicianId = 2,
-                    Time = new DateTime(2019, 11, 27, 15, 30, 0),
+                    Time = new DateTime(2019, 12, 2, 12, 30, 0),
                     Type = AppointmentType.Consultation
                 },
                 new Appointment
@@ -123,6 +123,14 @@ namespace WebClinicAPI.Data
                     PatientId = 6,
                     PhysicianId = 3,
                     Time = new DateTime(2019, 12, 3, 10, 0, 0),
+                    Type = AppointmentType.Consultation
+                },
+                new Appointment
+                {
+                    Id = 4,
+                    PatientId = 6,
+                    PhysicianId = 2,
+                    Time = new DateTime(2019, 11, 27, 12, 30, 0),
                     Type = AppointmentType.Consultation
                 });
             #endregion

--- a/WebClinicGUI/Controllers/AddAppointmentController.cs
+++ b/WebClinicGUI/Controllers/AddAppointmentController.cs
@@ -45,7 +45,7 @@ namespace WebClinicGUI.Controllers
                 var builder = new StringBuilder("Appointments/free/?");
                 var query = HttpUtility.ParseQueryString(string.Empty);
                 query["specialization"] = specialization.ToString();
-                query["startDate"] = startDate.ToString();
+                query["startDate"] = startDate.ToString("MM.dd.yyyy");  // little hack
                 query["type"] = appointmentType.ToString();
                 builder.Append(query.ToString());
 

--- a/WebClinicGUI/Controllers/AddAppointmentController.cs
+++ b/WebClinicGUI/Controllers/AddAppointmentController.cs
@@ -28,14 +28,14 @@ namespace WebClinicGUI.Controllers
 
         [HttpGet]
         [Authorize]
-        public async Task<IActionResult> Index(PhysicianSpecialization specialization, DateTime date, AppointmentType appointmentType)
+        public async Task<IActionResult> Index(PhysicianSpecialization specialization, DateTime startDate, AppointmentType appointmentType)
         {
             var model = new AddAppointmentViewModel
             {
                 FreeTerms = new List<Appointment>()
             };
 
-            if (date < DateTime.Now)
+            if (startDate < DateTime.Now)
             {
                 return View(model);
             }
@@ -45,9 +45,10 @@ namespace WebClinicGUI.Controllers
                 var builder = new StringBuilder("Appointments/free/?");
                 var query = HttpUtility.ParseQueryString(string.Empty);
                 query["specialization"] = specialization.ToString();
-                query["date"] = date.ToString();
+                query["startDate"] = startDate.ToString();
                 query["type"] = appointmentType.ToString();
                 builder.Append(query.ToString());
+
                 model.FreeTerms = await _client.SendRequestAsync<List<Appointment>>(HttpMethod.Get, builder.ToString());
                 return View(model);
             }

--- a/WebClinicGUI/Models/AddAppointment/AddAppointmentViewModel.cs
+++ b/WebClinicGUI/Models/AddAppointment/AddAppointmentViewModel.cs
@@ -13,9 +13,9 @@ namespace WebClinicGUI.Models
         public PhysicianSpecialization? Specialization { get; set; }
 
         [Required(ErrorMessage = "The '{0}' field is required.")]
-        [Display(Name = "Day of visit")]
+        [Display(Name = "Date start")]
         [DataType(DataType.Date)]
-        public DateTime? Date { get; set; }
+        public DateTime? StartDate { get; set; }
 
         [Required(ErrorMessage = "The '{0}' field is required.")]
         [Display(Name = "Type of appointment")]

--- a/WebClinicGUI/Resources/Models/AddAppointmentViewModel.pl.resx
+++ b/WebClinicGUI/Resources/Models/AddAppointmentViewModel.pl.resx
@@ -120,8 +120,8 @@
   <data name="Appointment type" xml:space="preserve">
     <value>Typ wizyty</value>
   </data>
-  <data name="Day of visit" xml:space="preserve">
-    <value>Data wizyty</value>
+  <data name="Date start" xml:space="preserve">
+    <value>Data wizyty od</value>
   </data>
   <data name="Physician" xml:space="preserve">
     <value>Lekarz</value>

--- a/WebClinicGUI/Views/AddAppointment/Index.cshtml
+++ b/WebClinicGUI/Views/AddAppointment/Index.cshtml
@@ -29,10 +29,10 @@
             </div>
 
             <div class="form-group">
-                @Html.LabelFor(model => model.Date, htmlAttributes: new { @class = "control-label" })
+                @Html.LabelFor(model => model.StartDate, htmlAttributes: new { @class = "control-label" })
                 <div class="col-md-10">
-                    @Html.EditorFor(model => model.Date, new { htmlAttributes = new { @class = "form-control" } })
-                    @Html.ValidationMessageFor(model => model.Date, "", new { @class = "text-danger" })
+                    @Html.EditorFor(model => model.StartDate, new { htmlAttributes = new { @class = "form-control" } })
+                    @Html.ValidationMessageFor(model => model.StartDate, "", new { @class = "text-danger" })
                 </div>
             </div>
 


### PR DESCRIPTION
Initial version.

Question: Do we allow users to specify also the end date of free appointments search time period, or just load some arbitrary number of free slots + maybe some pagination or lazy loading?